### PR TITLE
Remove OrderedLoader, sort responses by status code

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ setup(
     include_package_data=True,
     zip_safe=False,
     use_scm_version=True,
+    python_requires='>=3.6',
     setup_requires=[
         'setuptools_scm >= 1.15',
     ],

--- a/sphinxcontrib/openapi.py
+++ b/sphinxcontrib/openapi.py
@@ -24,22 +24,6 @@ from docutils.statemachine import ViewList
 
 from sphinx.util.nodes import nested_parse_with_titles
 
-
-# Dictionaries do not guarantee to preserve the keys order so when we load
-# JSON or YAML - we may loose the order. In most cases it's not important
-# because we're interested in data. However, in case of OpenAPI spec it'd
-# be really nice to preserve them since, for example, endpoints may be
-# grouped logically and that improved readability.
-class _YamlOrderedLoader(yaml.SafeLoader):
-    pass
-
-
-_YamlOrderedLoader.add_constructor(
-    yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG,
-    lambda loader, node: collections.OrderedDict(loader.construct_pairs(node))
-)
-
-
 def _resolve_refs(uri, spec):
     """Resolve JSON references in a given dictionary.
 
@@ -257,7 +241,7 @@ class OpenApi(Directive):
         # the one specified in Sphinx's config.
         encoding = self.options.get('encoding', env.config.source_encoding)
         with io.open(abspath, 'rt', encoding=encoding) as stream:
-            spec = yaml.load(stream, _YamlOrderedLoader)
+            spec = yaml.safe_load(stream)
 
         # URI parameter is crucial for resolving relative references. So
         # we need to set this option properly as it's used later down the

--- a/sphinxcontrib/openapi.py
+++ b/sphinxcontrib/openapi.py
@@ -85,8 +85,9 @@ def _httpresource(endpoint, method, properties):
         for line in param.get('description', '').splitlines():
             yield '{indent}{indent}{line}'.format(**locals())
 
-    # print response status codes
-    for status, response in responses.items():
+    # print response status codes in sorted order
+    for status in sorted(responses.keys()):
+        response = responses[status]
         yield '{indent}:status {status}:'.format(**locals())
         for line in response['description'].splitlines():
             yield '{indent}{indent}{line}'.format(**locals())


### PR DESCRIPTION
Requiring Python >= 3.0 (3.6, since that's what the pdns repo requires) ensures that dictionaries will preserve insertion order, so the OrderedLoader is no longer required for that purpose. Removing it re-enables various features of the BaseLoader without having to duplicate them, specifically the support for 'merge' keys.

In addition, responses are now ordered by status code (even if they were not defined that way in the spec file), so that the 'success' codes will appear before the 'failure' codes.